### PR TITLE
trim language so highlight function can match the language with spaces

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export default md => {
     const lineNumbers = RE.exec(token.info)[1]
       .split(',')
       .map(v => v.split('-').map(v => parseInt(v, 10)))
-    const langName = token.info.replace(RE, '')
+    const langName = token.info.replace(RE, '').trim()
 
     const code = options.highlight ?
       options.highlight(token.content, langName) :

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,7 @@ const a = b
 const a = b
 \`\`\`
 
-\`\`\`js{2-3}
+\`\`\` js {2-3}
 const a = b
 const c = d
 const d = e


### PR DESCRIPTION
Allows user to define lines like this:

```markdown
\`\`\`js {2}
\`\`\`

\`\`\` js {2}
\`\`\`
```

Benefits:

* Allows code inside fence to be highlighted by editor
