### PR TITLE
don't wrap code if already wrapped with <pre... by highlight fn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,10 @@ export default md => {
         highlightedCode += `${split.code}\n`
       }
     })
+    // If custom highlighter wraps code with starting <pre..., don't wrap code
+    if (highlightedCode.startsWith('<pre')) {
+      return highlightedCode
+    }
     const tmpToken = {
       attrs: [['class', langName ? `language-${langName}` : '']]
     }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -6,3 +6,11 @@ exports[`main 1`] = `
 <pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"highlighted-line\\">const a = b</span></code></pre><pre class=\\"language-js\\"><code class=\\"language-js\\">const a = b
 <span class=\\"highlighted-line\\">const c = d</span><span class=\\"highlighted-line\\">const d = e</span></code></pre>"
 `;
+
+exports[`respect custom <pre> 1`] = `
+"<pre class=\\"language-js\\"><code class=\\"language-js\\">const a = b
+</code></pre>
+<pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"highlighted-line\\"><pre class=\\"language-js\\"><code class=\\"language-js\\">const a = b</span></code></pre></code></pre><pre class=\\"language-js\\"><code class=\\"language-js\\">const a = b
+<span class=\\"highlighted-line\\">const c = d</span><span class=\\"highlighted-line\\">const d = e</span></code></pre>
+"
+`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,3 +22,29 @@ const d = e
 
   expect(html).toMatchSnapshot()
 })
+
+test('respect custom <pre>', () => {
+  const md = new Markdown({
+    highlight(code, language) {
+      return `<pre class="language-${language}"><code class="language-${language}">${code}</code></pre>`
+    }
+  })
+  md.use(highlightLines)
+  const html = md.render(`
+\`\`\`js
+const a = b
+\`\`\`
+
+\`\`\`js{1}
+const a = b
+\`\`\`
+
+\`\`\` js {2-3}
+const a = b
+const c = d
+const d = e
+\`\`\`
+  `)
+
+  expect(html).toMatchSnapshot()
+})


### PR DESCRIPTION
See https://github.com/markdown-it/markdown-it#init-with-presets-and-options:

```
  // Highlighter function. Should return escaped HTML,
  // or '' if the source string is not changed and should be escaped externally.
  // If result starts with <pre... internal wrapper is skipped.
  highlight: function (/*str, lang*/) { return ''; }
```